### PR TITLE
test: remove path mapped imports

### DIFF
--- a/package/src/decorators/sliced.decorator.spec.ts
+++ b/package/src/decorators/sliced.decorator.spec.ts
@@ -2,7 +2,7 @@
 // tslint:disable:max-line-length
 import { Routes } from '@angular/router';
 import { Sliced } from '.';
-import { createFeature, createRoot } from 'lib';
+import { createFeature, createRoot } from '../creators';
 import { PRIVATE_HUB_KEY } from '../constants';
 
 describe('Sliced decorator', () => {

--- a/package/src/functions/hub.spec.ts
+++ b/package/src/functions/hub.spec.ts
@@ -1,8 +1,7 @@
 import { Routes } from '@angular/router';
 import { getHubSlices, getSlice } from './';
 import { PRIVATE_HUB_KEY } from '../constants';
-import { createRoot } from '../creators/root.creator';
-import { createFeature } from 'lib';
+import { createFeature, createRoot } from '../creators';
 
 describe('Hub functions', () => {
   const appRoutes: Routes = [{ path: '' }, { path: '**' }, { path: 'map' }];


### PR DESCRIPTION
Remove path mapped imports in the format `import (...) from 'lib'` from tests.