### PR TITLE
test: remove barrel imports

### DIFF
--- a/package/src/decorators/sliced.decorator.spec.ts
+++ b/package/src/decorators/sliced.decorator.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-classes-per-file
 // tslint:disable:max-line-length
 import { Routes } from '@angular/router';
-import { Sliced } from '.';
+import { Sliced } from './sliced.decorator';
 import { createFeature, createRoot } from '../creators';
 import { PRIVATE_HUB_KEY } from '../constants';
 

--- a/package/src/functions/forward-params.spec.ts
+++ b/package/src/functions/forward-params.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-line-length
 import { Routes } from '@angular/router';
+import { forwardParams } from './forward-params';
 import { createRoot } from '../creators/root.creator';
-import { forwardParams } from './';
 
 describe('forwardParams', () => {
   it('should return the same state', () => {

--- a/package/src/functions/hub.spec.ts
+++ b/package/src/functions/hub.spec.ts
@@ -1,5 +1,5 @@
 import { Routes } from '@angular/router';
-import { getHubSlices, getSlice } from './';
+import { getHubSlices, getSlice } from './hub';
 import { PRIVATE_HUB_KEY } from '../constants';
 import { createFeature, createRoot } from '../creators';
 


### PR DESCRIPTION
Let's keep import statements in tests consistent. Importing from the ES module in question instead of the neareste barrel is the usual way to do it with ES module-specific test suites.